### PR TITLE
FEAT validacion largo de tipo TEXT

### DIFF
--- a/src/models/Blogs.js
+++ b/src/models/Blogs.js
@@ -22,6 +22,9 @@ module.exports = (sequelize) => {
             description: {
                 type: DataTypes.TEXT,
                 allowNull: false,
+                validate: {
+                    len: [0, 2000]
+                }
             },
             active: {
                 type: DataTypes.BOOLEAN,

--- a/src/models/Blogs.js
+++ b/src/models/Blogs.js
@@ -23,7 +23,7 @@ module.exports = (sequelize) => {
                 type: DataTypes.TEXT,
                 allowNull: false,
                 validate: {
-                    len: [0, 2000]
+                    len: [1, 2000]
                 }
             },
             active: {

--- a/src/models/Categories.js
+++ b/src/models/Categories.js
@@ -14,7 +14,7 @@ module.exports = (sequelize) => {
             allowNull: false,
         },
         description: {
-            type: DataTypes.TEXT,
+            type: DataTypes.STRING,
         },
         image: {
             type: DataTypes.STRING,
@@ -22,5 +22,4 @@ module.exports = (sequelize) => {
         },
     },
         { timestamps: true });
-
 };

--- a/src/models/Products.js
+++ b/src/models/Products.js
@@ -64,6 +64,9 @@ module.exports = (sequelize) => {
         description: {
             type: DataTypes.TEXT,
             allowNull: true,
+            validate: {
+                len: [0, 1000]
+            }
         },
         nroReviews: {
             type: DataTypes.FLOAT,

--- a/src/models/Users.js
+++ b/src/models/Users.js
@@ -20,6 +20,7 @@ module.exports = (sequelize) => {
         },
         password: {
             type: DataTypes.STRING,
+            allowNull: false,
         },
         rol: {
             type: DataTypes.STRING,
@@ -39,7 +40,6 @@ module.exports = (sequelize) => {
         address: {
             type: DataTypes.STRING,
             allowNull: true,
-
         },
         locality: {
             type: DataTypes.STRING,


### PR DESCRIPTION
Los dataTypes tipo STRING tienen un limite de 255 caracteres en sequelize, lo cual para las descripciones de algunas tablas no eran suficiente, por ej: Blog y tuvimos que usar dataTypes TEXT en su momento ya que permiten superar esa cantidad y agregar descripciones largas, lo cual por seguridad hacia falta limitar.

ej: 2000 caracteres para descripción de Blog
1000 caracteres para descripcion de Producto.
